### PR TITLE
Set a default value for the GitHub token input

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,19 @@ jobs:
     steps:
       - uses: conjikidow/bump-version@v1.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           labels-to-add: "automated,version-bump"
 ```
 
 ### Inputs
 
-| Name                         | Description                                     | Required | Default           |
-|------------------------------|-------------------------------------------------|:--------:|-------------------|
-| `github-token`               | The GitHub token for authentication             | Yes      | N/A               |
-| `version-of-bump-my-version` | The version of `bump-my-version` to use         | No       | `"latest"`        |
-| `label-major`                | The label used to trigger a major version bump  | No       | `"update::major"` |
-| `label-minor`                | The label used to trigger a minor version bump  | No       | `"update::minor"` |
-| `label-patch`                | The label used to trigger a patch version bump  | No       | `"update::patch"` |
-| `labels-to-add`              | The labels to add to the PR for version bumping | No       | None              |
+| Name                         | Description                                     | Required | Default               |
+|------------------------------|-------------------------------------------------|:--------:|-----------------------|
+| `github-token`               | The GitHub token for authentication             | No       | `${{ github.token }}` |
+| `version-of-bump-my-version` | The version of `bump-my-version` to use         | No       | `"latest"`            |
+| `label-major`                | The label used to trigger a major version bump  | No       | `"update::major"`     |
+| `label-minor`                | The label used to trigger a minor version bump  | No       | `"update::minor"`     |
+| `label-patch`                | The label used to trigger a patch version bump  | No       | `"update::patch"`     |
+| `labels-to-add`              | The labels to add to the PR for version bumping | No       | None                  |
 
 ### bump-my-version Configuration
 

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,8 @@ author: "conjikidow"
 inputs:
   github-token:
     description: "GitHub Token"
-    required: true
+    required: false
+    default: ${{ github.token }}
   version-of-bump-my-version:
     description: "Version of bump-my-version"
     required: false


### PR DESCRIPTION
This PR improves the action by setting a default value for the `github-token` input.

Previously, users were required to explicitly pass `${{ secrets.GITHUB_TOKEN }}` for authentication. Now, the action will default to `${{ github.token }}`, allowing it to work without additional configuration.