### PR TITLE
Update Existing Major and Minor Version Tags on Version Bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,19 @@ Follow these steps to configure the permissions:
 5. After merging, creates a Git tag
    - The branch name is parsed to extract the new version number.
    - A Git tag (`vX.Y.Z`) is pushed to mark the new release.
+
+### Tag Management
+
+In addition to the full version tag (`vX.Y.Z`), this action updates existing major (`vX`) and minor (`vX.Y`) tags based on the following rules:
+
+- If `vX.Y` exists → update to `vX.Y.Z`.
+- If `vX.Y` does not exist but a previous minor tag (`vX.Y` before the update) exists → create `vX.Y` and set it to `vX.Y.Z`.
+- If `vX` exists → update to `vX.Y.Z`.
+- If `vX` does not exist but a previous major tag (`vX` before the update) exists → create `vX` and set it to `vX.Y.Z`.
+- If neither `vX` nor `vX.Y` exist, they are not created.
+
+#### Examples
+
+- `v1.2.3 → v1.2.4`: Update `v1.2` and `v1` if they exist.
+- `v1.2.3 → v1.3.0`: Create `v1.3` if `v1.2` exists, update `v1` if it exists.
+- `v1.2.3 → v2.0.0`: Create `v2.0` if `v1.2` exists, create `v2` if `v1` exists.

--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -29,16 +29,27 @@ new_minor_version=$(cut -d. -f1,2 <<< "$new_version")
 git tag "v${new_version}" "$MERGE_COMMIT_SHA"
 git push origin "v${new_version}"
 
-# Update minor tag only if the minor version changed
-if [[ "$previous_minor_version" != "$new_minor_version" ]]; then
-    echo "Updating minor tag: v${new_minor_version}"
-    git tag -f "v${new_minor_version}" "$MERGE_COMMIT_SHA"
-    git push -f origin "v${new_minor_version}"
-fi
+existing_previous_major_tag=$(git ls-remote --tags origin "v${previous_major_version}" | awk '{print $2}')
+existing_previous_minor_tag=$(git ls-remote --tags origin "v${previous_minor_version}" | awk '{print $2}')
+existing_major_tag=$(git ls-remote --tags origin "v${new_major_version}" | awk '{print $2}')
+existing_minor_tag=$(git ls-remote --tags origin "v${new_minor_version}" | awk '{print $2}')
 
-# Update major tag only if the major version changed
-if [[ "$previous_major_version" != "$new_major_version" ]]; then
+if [[ -n "$existing_major_tag" ]]; then
     echo "Updating major tag: v${new_major_version}"
     git tag -f "v${new_major_version}" "$MERGE_COMMIT_SHA"
     git push -f origin "v${new_major_version}"
+elif [[ -n "$existing_previous_major_tag" ]]; then
+    echo "Creating new major tag: v${new_major_version} (previous major v${previous_major_version} exists)"
+    git tag "v${new_major_version}" "$MERGE_COMMIT_SHA"
+    git push origin "v${new_major_version}"
+fi
+
+if [[ -n "$existing_minor_tag" ]]; then
+    echo "Updating minor tag: v${new_minor_version}"
+    git tag -f "v${new_minor_version}" "$MERGE_COMMIT_SHA"
+    git push -f origin "v${new_minor_version}"
+elif [[ -n "$existing_previous_minor_tag" ]]; then
+    echo "Creating new minor tag: v${new_minor_version} (previous minor v${previous_minor_version} exists)"
+    git tag "v${new_minor_version}" "$MERGE_COMMIT_SHA"
+    git push origin "v${new_minor_version}"
 fi

--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -10,15 +10,35 @@ if [ -z "$branch_name" ]; then
 fi
 
 # Verify if branch_name matches the expected pattern
-branch_name=$(echo "$branch_name" | grep -E '^workflow/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-[0-9]+\.[0-9]+\.[0-9]+$' || echo "nomatch")
-if [ "$branch_name" == "nomatch" ]; then
+if ! [[ "$branch_name" =~ ^workflow/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "This branch does not match the expected pattern. Skipping."
     exit 0
 fi
 
-# Extract the version from the branch name
-current_version=$(echo "$branch_name" | sed -E 's/^workflow\/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+# Extract versions from the branch name
+previous_version=$(echo "$branch_name" | sed -E 's/^workflow\/bump-version-from-([0-9]+\.[0-9]+\.[0-9]+)-to-[0-9]+\.[0-9]+\.[0-9]+$/\1/')
+new_version=$(echo "$branch_name" | sed -E 's/^workflow\/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
 
+# Extract major and minor versions
+previous_major_version=$(cut -d. -f1 <<< "$previous_version")
+previous_minor_version=$(cut -d. -f1,2 <<< "$previous_version")
+new_major_version=$(cut -d. -f1 <<< "$new_version")
+new_minor_version=$(cut -d. -f1,2 <<< "$new_version")
 
-git tag "v${current_version}" "$MERGE_COMMIT_SHA"
-git push origin "v${current_version}"
+# Create full version tag (e.g., v1.2.3)
+git tag "v${new_version}" "$MERGE_COMMIT_SHA"
+git push origin "v${new_version}"
+
+# Update minor tag only if the minor version changed
+if [[ "$previous_minor_version" != "$new_minor_version" ]]; then
+    echo "Updating minor tag: v${new_minor_version}"
+    git tag -f "v${new_minor_version}" "$MERGE_COMMIT_SHA"
+    git push -f origin "v${new_minor_version}"
+fi
+
+# Update major tag only if the major version changed
+if [[ "$previous_major_version" != "$new_major_version" ]]; then
+    echo "Updating major tag: v${new_major_version}"
+    git tag -f "v${new_major_version}" "$MERGE_COMMIT_SHA"
+    git push -f origin "v${new_major_version}"
+fi


### PR DESCRIPTION
This PR enables updating existing major (`vX`) and minor (`vX.Y`) tags on version bump and creates them when necessary.

### Behavior Examples
| Previous Version | New Version | `vX.Y` Action | `vX` Action |
|----------------|------------|-------------|------------|
| `v1.2.3`      | `v1.2.4`   | Update `v1.2` (if exists) | Update `v1` (if exists) |
| `v1.2.3`      | `v1.3.0`   | Create `v1.3` (if `v1.2` exists) | Update `v1` (if exists) |
| `v1.2.3`      | `v2.0.0`   | Create `v2.0` (if `v1.2` exists) | Create `v2` (if `v1` exists) |

Closes #20 