### PR TITLE
Update conjikidow/bump-version action to v1.1.0

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -13,6 +13,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: conjikidow/bump-version@v1.0.2
+      - uses: conjikidow/bump-version@v1.1.0
         with:
           labels-to-add: "automated,versioning"


### PR DESCRIPTION
This PR updates conjikidow/bump-version action to v1.1.0.