### PR TITLE
Update Renovate Bot config to pin GHA with commit SHA

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,13 @@
   extends: [
     "config:recommended",
   ],
+  packageRules: [
+    {
+      "matchDepTypes": ["action"],
+      "excludePackagePrefixes": ["conjikidow/bump-version"],
+      "pinDigests": true,
+    },
+  ],
   labels: [
     "automated",
     "dependencies",


### PR DESCRIPTION
Renovate bot is expected to pin the GitHub actions with commit SHA automatically. 