### PR TITLE
Set up template sync

### DIFF
--- a/.github/.templatesyncignore
+++ b/.github/.templatesyncignore
@@ -1,0 +1,4 @@
+README.md
+.bumpversion.toml
+.typos.toml
+.github/CODEOWNERS

--- a/.github/workflows/sync-template.yaml
+++ b/.github/workflows/sync-template.yaml
@@ -1,0 +1,26 @@
+name: Sync Template Repository
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+
+  sync-repo:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout the main repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: actions-template-sync
+        uses: AndreasAugustin/actions-template-sync@bcb94410a4f1dffdfe5eaabc8234c3b8e76ebc5b # v2.5.1
+        with:
+          source_repo_path: conjikidow/repository-template
+          upstream_branch: main
+          pr_branch_name_prefix: 'workflow/sync-template'
+          pr_labels: 'automated,template-sync'


### PR DESCRIPTION
This pull request introduces changes to support syncing this repository with a template repository.

Template synchronization setup:

* [`.github/workflows/sync-template.yaml`](diffhunk://#diff-df64ff28cf1063884db43ce123455591e6c97321bfb1f177e2f3e1228628c683R1-R26): Added a new GitHub Actions workflow to automate synchronization with the upstream template repository. 

* [`.github/.templatesyncignore`](diffhunk://#diff-62ac2cb6dd2a2cbb21638dbd3a49c85e5bce4b4f979f7045c087ff9a2eab7809R1-R4): Added a list of files to exclude from synchronization with the template repository.