### PR TITLE
Skip empty label names in bump detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ jobs:
 | `label-patch`                | The label used to trigger a patch version bump  | No       | `"patch"`     |
 | `labels-to-add`              | The labels to add to the PR for version bumping | No       | None                  |
 
-> **Note:** Any labels specified in `labels-to-add` must already exist in your repository. If they do not, create them in advance to avoid errors.
+> [!TIP]
+> Set any of `label-major`, `label-minor`, or `label-patch` to an empty string (`''`) if you want to disable that bump type.
+
+> [!WARNING]
+> Any labels specified in `labels-to-add` must already exist in your repository. If they do not, create them in advance to avoid errors.
 
 ### bump-my-version Configuration
 
@@ -83,7 +87,8 @@ search = "VERSION {current_version}"
 replace = "VERSION {new_version}"
 ```
 
-> **Note:** `commit` and `tag` should be set to `false` because this action handles these tasks automatically.
+> [!IMPORTANT]
+> `commit` and `tag` should be set to `false` because this action handles these tasks automatically.
 
 To generate a default configuration file, run the following command:
 

--- a/src/determine-bump-type.sh
+++ b/src/determine-bump-type.sh
@@ -4,13 +4,19 @@ set -e
 # Fetch PR labels
 labels=$(gh api --jq '.labels.[].name' "/repos/${REPO}/pulls/${PR_NUMBER}" | tr '\n' ',' | sed 's/,$//')
 
+# Return success if a non-empty label name is found inside $labels
+has_label() {
+  local needle=$1
+  [[ -n "$needle" && "$labels" == *"$needle"* ]]
+}
+
 # Determine bump type
 bump_type="none"
-if [[ "$labels" == *"$LABEL_MAJOR"* ]]; then
+if has_label "$LABEL_MAJOR"; then
   bump_type="major"
-elif [[ "$labels" == *"$LABEL_MINOR"* ]]; then
+elif has_label "$LABEL_MINOR"; then
   bump_type="minor"
-elif [[ "$labels" == *"$LABEL_PATCH"* ]]; then
+elif has_label "$LABEL_PATCH"; then
   bump_type="patch"
 fi
 


### PR DESCRIPTION
Closes #72

This PR prevents empty `LABEL_*` variables from matching every pull-request label.
The fix adds a length check in `src/determine-bump-type.sh`.