### PR TITLE
Fix: Set default value for labels-to-add to empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
 | `label-major`                | The label used to trigger a major version bump  | No       | `"major"`     |
 | `label-minor`                | The label used to trigger a minor version bump  | No       | `"minor"`     |
 | `label-patch`                | The label used to trigger a patch version bump  | No       | `"patch"`     |
-| `labels-to-add`              | The labels to add to the PR for version bumping | No       | None                  |
+| `labels-to-add`              | The labels to add to the PR for version bumping | No       | `""`                  |
 
 > [!TIP]
 > Set any of `label-major`, `label-minor`, or `label-patch` to an empty string (`''`) if you want to disable that bump type.

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ jobs:
 | Name                         | Description                                     | Required | Default               |
 |------------------------------|-------------------------------------------------|:--------:|-----------------------|
 | `github-token`               | The GitHub token for authentication             | No       | `${{ github.token }}` |
-| `version-of-bump-my-version` | The version of `bump-my-version` to use         | No       | `"latest"`            |
-| `label-major`                | The label used to trigger a major version bump  | No       | `"major"`     |
-| `label-minor`                | The label used to trigger a minor version bump  | No       | `"minor"`     |
-| `label-patch`                | The label used to trigger a patch version bump  | No       | `"patch"`     |
-| `labels-to-add`              | The labels to add to the PR for version bumping | No       | `""`                  |
+| `version-of-bump-my-version` | The version of `bump-my-version` to use         | No       | `'latest'`            |
+| `label-major`                | The label used to trigger a major version bump  | No       | `'major'`     |
+| `label-minor`                | The label used to trigger a minor version bump  | No       | `'minor'`     |
+| `label-patch`                | The label used to trigger a patch version bump  | No       | `'patch'`     |
+| `labels-to-add`              | The labels to add to the PR for version bumping | No       | `''`                  |
 
 > [!TIP]
 > Set any of `label-major`, `label-minor`, or `label-patch` to an empty string (`''`) if you want to disable that bump type.

--- a/action.yaml
+++ b/action.yaml
@@ -1,35 +1,35 @@
-name: "Bump Version by Labels"
-description: "Automatically bumps version based on PR labels and creates a pull request and tag."
-author: "conjikidow"
+name: 'Bump Version by Labels'
+description: 'Automatically bumps version based on PR labels and creates a pull request and tag.'
+author: 'conjikidow'
 
 inputs:
   github-token:
-    description: "GitHub Token"
+    description: 'GitHub Token'
     required: false
     default: ${{ github.token }}
   version-of-bump-my-version:
-    description: "Version of bump-my-version"
+    description: 'Version of bump-my-version'
     required: false
-    default: "latest"
+    default: 'latest'
   label-major:
-    description: "Label for major update"
+    description: 'Label for major update'
     required: false
-    default: "major"
+    default: 'major'
   label-minor:
-    description: "Label for minor update"
+    description: 'Label for minor update'
     required: false
-    default: "minor"
+    default: 'minor'
   label-patch:
-    description: "Label for patch update"
+    description: 'Label for patch update'
     required: false
-    default: "patch"
+    default: 'patch'
   labels-to-add:
-    description: "Labels to add to the pull request"
+    description: 'Labels to add to the pull request'
     required: false
-    default: ""
+    default: ''
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Check if PR is merged
       shell: bash
@@ -89,5 +89,5 @@ runs:
         MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
 
 branding:
-  icon: "chevrons-up"
-  color: "green"
+  icon: 'chevrons-up'
+  color: 'green'

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ inputs:
   labels-to-add:
     description: "Labels to add to the pull request"
     required: false
-    default: None
+    default: ""
 
 runs:
   using: "composite"


### PR DESCRIPTION
This PR fixes an issue where the `labels-to-add` input had a default value of `None`, which caused problems with the `gh pr create` command. The default value has been changed to an empty string (`''`) to ensure compatibility.

Additionally, all double quotes for default values in `README.md` and `action.yaml` have been replaced with single quotes for consistency.