### PR TITLE
Refactor: Optimize git ls-remote calls in create-tag.sh

### DIFF
--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -29,10 +29,14 @@ new_minor_version=$(cut -d. -f1,2 <<< "$new_version")
 git tag "v${new_version}" "$MERGE_COMMIT_SHA"
 git push origin "v${new_version}"
 
-existing_previous_major_tag=$(git ls-remote --tags origin "v${previous_major_version}" | awk '{print $2}')
-existing_previous_minor_tag=$(git ls-remote --tags origin "v${previous_minor_version}" | awk '{print $2}')
-existing_major_tag=$(git ls-remote --tags origin "v${new_major_version}" | awk '{print $2}')
-existing_minor_tag=$(git ls-remote --tags origin "v${new_minor_version}" | awk '{print $2}')
+# Fetch all tags from the remote
+all_tags=$(git ls-remote --tags origin)
+
+# Check for existing tags in the fetched list
+existing_previous_major_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${previous_major_version}$" || true)
+existing_previous_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${previous_minor_version}$" || true)
+existing_major_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${new_major_version}$" || true)
+existing_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v${new_minor_version}$" || true)
 
 if [[ -n "$existing_major_tag" ]]; then
     echo "Updating major tag: v${new_major_version}"


### PR DESCRIPTION
This PR refactors the `create-tag.sh` script to improve performance by reducing the number of `git ls-remote` calls. Previously, the script made four separate calls to check for the existence of different tags. This has been optimized to a single `git ls-remote` call that fetches all tags, followed by local `grep` commands to find the required tags.

This change reduces network overhead and makes the script more efficient.