### PR TITLE
Refactor: Optimize git push in create-tag.sh

### DIFF
--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -27,7 +27,7 @@ new_minor_version=$(cut -d. -f1,2 <<< "$new_version")
 
 # Create full version tag (e.g., v1.2.3)
 git tag "v${new_version}" "$MERGE_COMMIT_SHA"
-git push origin "v${new_version}"
+tags_to_push="v${new_version}"
 
 # Fetch all tags from the remote
 all_tags=$(git ls-remote --tags origin)
@@ -41,19 +41,21 @@ existing_minor_tag=$(echo "$all_tags" | awk '{print $2}' | grep -E "^refs/tags/v
 if [[ -n "$existing_major_tag" ]]; then
     echo "Updating major tag: v${new_major_version}"
     git tag -f "v${new_major_version}" "$MERGE_COMMIT_SHA"
-    git push -f origin "v${new_major_version}"
+    tags_to_push+=" v${new_major_version}"
 elif [[ -n "$existing_previous_major_tag" ]]; then
     echo "Creating new major tag: v${new_major_version} (previous major v${previous_major_version} exists)"
     git tag "v${new_major_version}" "$MERGE_COMMIT_SHA"
-    git push origin "v${new_major_version}"
+    tags_to_push+=" v${new_major_version}"
 fi
 
 if [[ -n "$existing_minor_tag" ]]; then
     echo "Updating minor tag: v${new_minor_version}"
     git tag -f "v${new_minor_version}" "$MERGE_COMMIT_SHA"
-    git push -f origin "v${new_minor_version}"
+    tags_to_push+=" v${new_minor_version}"
 elif [[ -n "$existing_previous_minor_tag" ]]; then
     echo "Creating new minor tag: v${new_minor_version} (previous minor v${previous_minor_version} exists)"
     git tag "v${new_minor_version}" "$MERGE_COMMIT_SHA"
-    git push origin "v${new_minor_version}"
+    tags_to_push+=" v${new_minor_version}"
 fi
+
+git push origin $tags_to_push


### PR DESCRIPTION
This PR refactors the  script to optimize  operations. Instead of pushing individual tags as they are created or updated, all relevant tags are now collected and pushed in a single  command at the end of the script. This reduces network overhead and improves efficiency.