### PR TITLE
feat: Make branch prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ jobs:
 |------------------------------|-------------------------------------------------|:--------:|-----------------------|
 | `github-token`               | The GitHub token for authentication             | No       | `${{ github.token }}` |
 | `version-of-bump-my-version` | The version of `bump-my-version` to use         | No       | `'latest'`            |
-| `label-major`                | The label used to trigger a major version bump  | No       | `'major'`     |
-| `label-minor`                | The label used to trigger a minor version bump  | No       | `'minor'`     |
-| `label-patch`                | The label used to trigger a patch version bump  | No       | `'patch'`     |
+| `label-major`                | The label used to trigger a major version bump  | No       | `'major'`             |
+| `label-minor`                | The label used to trigger a minor version bump  | No       | `'minor'`             |
+| `label-patch`                | The label used to trigger a patch version bump  | No       | `'patch'`             |
+| `branch-prefix`              | The prefix for the version bump branch name     | No       | `'workflow'`          |
 | `labels-to-add`              | The labels to add to the PR for version bumping | No       | `''`                  |
 
 > [!TIP]
@@ -127,7 +128,7 @@ Follow these steps to configure the permissions:
    - Checks if the version was actually updated.
 
 4. Creates a new branch and PR for the version bump
-   - If the version is updated, a new branch (`workflow/bump-version-from-X.Y.W-to-X.Y.Z`) is created.
+   - If the version is updated, a new branch (`${branch-prefix}/bump-version-from-X.Y.W-to-X.Y.Z`) is created.
    - A PR is automatically opened to merge the version bump.
 
 5. After merging, creates a Git tag

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,10 @@ inputs:
     description: 'Label for patch update'
     required: false
     default: 'patch'
+  branch-prefix:
+    description: 'Prefix for the version bump branch name'
+    required: false
+    default: 'workflow'
   labels-to-add:
     description: 'Labels to add to the pull request'
     required: false
@@ -78,6 +82,7 @@ runs:
         VERSION_OF_BUMP_MY_VERSION: ${{ inputs.version-of-bump-my-version }}
         BUMP_TYPE: ${{ steps.bump-type.outputs.type }}
         LABELS_TO_ADD: ${{ inputs.labels-to-add }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
 
     - name: Create tag
       if: env.SKIP_JOB != 'true'
@@ -87,6 +92,7 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         HEAD_REF: ${{ github.event.pull_request.head.ref }}
         MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
 
 branding:
   icon: 'chevrons-up'

--- a/src/bump-version.sh
+++ b/src/bump-version.sh
@@ -20,7 +20,7 @@ fi
 base_branch=$(git branch --show-current)
 
 # Create a new branch for the version bump
-new_branch="workflow/bump-version-from-${previous_version}-to-${current_version}"
+new_branch="${BRANCH_PREFIX}/bump-version-from-${previous_version}-to-${current_version}"
 git checkout -b "$new_branch"
 
 # Commit the version bump changes

--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -10,14 +10,14 @@ if [ -z "$branch_name" ]; then
 fi
 
 # Verify if branch_name matches the expected pattern
-if ! [[ "$branch_name" =~ ^workflow/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if ! [[ "$branch_name" =~ ^${BRANCH_PREFIX}/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "This branch does not match the expected pattern. Skipping."
     exit 0
 fi
 
 # Extract versions from the branch name
-previous_version=$(echo "$branch_name" | sed -E 's/^workflow\/bump-version-from-([0-9]+\.[0-9]+\.[0-9]+)-to-[0-9]+\.[0-9]+\.[0-9]+$/\1/')
-new_version=$(echo "$branch_name" | sed -E 's/^workflow\/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+previous_version=$(echo "$branch_name" | sed -E "s/^${BRANCH_PREFIX}\/bump-version-from-([0-9]+\.[0-9]+\.[0-9]+)-to-[0-9]+\.[0-9]+\.[0-9]+$/\1/")
+new_version=$(echo "$branch_name" | sed -E "s/^${BRANCH_PREFIX}\/bump-version-from-[0-9]+\.[0-9]+\.[0-9]+-to-([0-9]+\.[0-9]+\.[0-9]+)$/\1/")
 
 # Extract major and minor versions
 previous_major_version=$(cut -d. -f1 <<< "$previous_version")


### PR DESCRIPTION
This PR introduces a new input `branch-prefix` to allow customization of the prefix used for version bump branch names. Previously, the prefix `workflow/` was hardcoded in src/bump-version.sh and src/create-tag.sh.

With this change, users can now specify their desired branch prefix, providing more flexibility and adherence to repository-specific branching conventions. The default value for branch-prefix remains `workflow`.

  This change affects:
   - action.yaml: Added `branch-prefix` input.
   - src/bump-version.sh: Updated to use `BRANCH_PREFIX` environment variable.
   - src/create-tag.sh: Updated to use `BRANCH_PREFIX` environment variable for branch name pattern matching and `sed` commands.
   - README.md: Updated to document the new `branch-prefix` input and reflect its usage in the "How It Works" section.