### PR TITLE
feat: Add auto-release functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ jobs:
 | `label-minor`                | The label used to trigger a minor version bump  | No       | `'minor'`             |
 | `label-patch`                | The label used to trigger a patch version bump  | No       | `'patch'`             |
 | `branch-prefix`              | The prefix for the version bump branch name     | No       | `'workflow'`          |
+| `create-release`             | Whether to create a GitHub Release for the new tag. | No       | `'false'`             |
 | `labels-to-add`              | The labels to add to the PR for version bumping | No       | `''`                  |
 
 > [!TIP]
@@ -134,6 +135,9 @@ Follow these steps to configure the permissions:
 5. After merging, creates a Git tag
    - The branch name is parsed to extract the new version number.
    - A Git tag (`vX.Y.Z`) is pushed to mark the new release.
+
+6. Optionally creates a GitHub Release
+   - If `create-release` is set to `true`, a GitHub Release is created for the new tag, with automatically generated release notes.
 
 ### Tag Management
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ jobs:
 
 ### Inputs
 
-| Name                         | Description                                     | Required | Default               |
-|------------------------------|-------------------------------------------------|:--------:|-----------------------|
-| `github-token`               | The GitHub token for authentication             | No       | `${{ github.token }}` |
-| `version-of-bump-my-version` | The version of `bump-my-version` to use         | No       | `'latest'`            |
-| `label-major`                | The label used to trigger a major version bump  | No       | `'major'`             |
-| `label-minor`                | The label used to trigger a minor version bump  | No       | `'minor'`             |
-| `label-patch`                | The label used to trigger a patch version bump  | No       | `'patch'`             |
-| `branch-prefix`              | The prefix for the version bump branch name     | No       | `'workflow'`          |
+| Name                         | Description                                         | Required | Default               |
+|------------------------------|-----------------------------------------------------|----------|-----------------------|
+| `github-token`               | The GitHub token for authentication                 | No       | `${{ github.token }}` |
+| `version-of-bump-my-version` | The version of `bump-my-version` to use             | No       | `'latest'`            |
+| `label-major`                | The label used to trigger a major version bump      | No       | `'major'`             |
+| `label-minor`                | The label used to trigger a minor version bump      | No       | `'minor'`             |
+| `label-patch`                | The label used to trigger a patch version bump      | No       | `'patch'`             |
+| `branch-prefix`              | The prefix for the version bump branch name         | No       | `'workflow'`          |
+| `labels-to-add`              | The labels to add to the PR for version bumping     | No       | `''`                  |
 | `create-release`             | Whether to create a GitHub Release for the new tag. | No       | `'false'`             |
-| `labels-to-add`              | The labels to add to the PR for version bumping | No       | `''`                  |
 
 > [!TIP]
 > Set any of `label-major`, `label-minor`, or `label-patch` to an empty string (`''`) if you want to disable that bump type.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
           label-minor: 'minor update'
           label-patch: 'patch update'
           labels-to-add: 'automated,version-bump'
+          create-release: 'true'
 ```
 
 ### Inputs

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,10 @@ inputs:
     description: 'Prefix for the version bump branch name'
     required: false
     default: 'workflow'
+  create-release:
+    description: 'Whether to create a GitHub Release for the new tag.'
+    required: false
+    default: 'false'
   labels-to-add:
     description: 'Labels to add to the pull request'
     required: false
@@ -93,6 +97,15 @@ runs:
         HEAD_REF: ${{ github.event.pull_request.head.ref }}
         MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+
+    - name: Create GitHub Release
+      if: env.SKIP_JOB != 'true' && inputs.create-release == 'true'
+      shell: bash
+      run: ${{ github.action_path }}/src/create-release.sh
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        NEW_VERSION_TAG: v${{ steps.create-tag.outputs.new-version }}
+        MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
 
 branding:
   icon: 'chevrons-up'

--- a/action.yaml
+++ b/action.yaml
@@ -90,6 +90,7 @@ runs:
 
     - name: Create tag
       if: env.SKIP_JOB != 'true'
+      id: create-tag
       shell: bash
       run: ${{ github.action_path }}/src/create-tag.sh
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -27,14 +27,14 @@ inputs:
     description: 'Prefix for the version bump branch name'
     required: false
     default: 'workflow'
-  create-release:
-    description: 'Whether to create a GitHub Release for the new tag.'
-    required: false
-    default: 'false'
   labels-to-add:
     description: 'Labels to add to the pull request'
     required: false
     default: ''
+  create-release:
+    description: 'Whether to create a GitHub Release for the new tag.'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'

--- a/src/create-release.sh
+++ b/src/create-release.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Ensure GH_TOKEN is set
+if [ -z "$GH_TOKEN" ]; then
+    echo "GH_TOKEN is not set. Exiting."
+    exit 1
+fi
+
+# Ensure NEW_VERSION_TAG is set
+if [ -z "$NEW_VERSION_TAG" ]; then
+    echo "NEW_VERSION_TAG is not set. Exiting."
+    exit 1
+fi
+
+# Ensure MERGE_COMMIT_SHA is set
+if [ -z "$MERGE_COMMIT_SHA" ]; then
+    echo "MERGE_COMMIT_SHA is not set. Exiting."
+    exit 1
+fi
+
+# Create GitHub Release
+# --generate-notes will automatically generate release notes based on git history
+gh release create "$NEW_VERSION_TAG" --target "$MERGE_COMMIT_SHA" --generate-notes

--- a/src/create-tag.sh
+++ b/src/create-tag.sh
@@ -57,3 +57,5 @@ elif [[ -n "$existing_previous_minor_tag" ]]; then
     git tag "v${new_minor_version}" "$MERGE_COMMIT_SHA"
     git push origin "v${new_minor_version}"
 fi
+
+echo "new-version=${new_version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR introduces the auto-release functionality to the action.\n\n- Adds `create-release` input to `action.yaml` to control release creation.\n- Updates `README.md` to document the new input and feature.\n- Adds `src/create-release.sh` to handle GitHub Release creation.\n- Ensures `new-version` output is available for release creation.