### PR TITLE
docs: Refine descriptions for inputs and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ jobs:
 
 ### Inputs
 
-| Name                         | Description                                         | Required | Default               |
-|------------------------------|-----------------------------------------------------|----------|-----------------------|
-| `github-token`               | The GitHub token for authentication.                | No       | `${{ github.token }}` |
-| `version-of-bump-my-version` | The version of `bump-my-version` to use.            | No       | `'latest'`            |
-| `label-major`                | The label used to trigger a major version bump.     | No       | `'major'`             |
-| `label-minor`                | The label used to trigger a minor version bump.     | No       | `'minor'`             |
-| `label-patch`                | The label used to trigger a patch version bump.     | No       | `'patch'`             |
-| `branch-prefix`              | The prefix for the version bump branch name.        | No       | `'workflow'`          |
-| `labels-to-add`              | The labels to add to the PR for version bumping.    | No       | `''`                  |
-| `create-release`             | Whether to create a GitHub Release for the new tag. | No       | `'false'`             |
+| Name                         | Description                                                            | Required | Default               |
+|------------------------------|------------------------------------------------------------------------|----------|-----------------------|
+| `github-token`               | The GitHub token for authentication.                                   | No       | `${{ github.token }}` |
+| `version-of-bump-my-version` | The version of `bump-my-version` to use.                               | No       | `'latest'`            |
+| `label-major`                | The label used to trigger a major version bump.                        | No       | `'major'`             |
+| `label-minor`                | The label used to trigger a minor version bump.                        | No       | `'minor'`             |
+| `label-patch`                | The label used to trigger a patch version bump.                        | No       | `'patch'`             |
+| `branch-prefix`              | The prefix for the version bump branch name.                           | No       | `'workflow'`          |
+| `labels-to-add`              | Comma-separated string of labels to add to the PR for version bumping. | No       | `''`                  |
+| `create-release`             | Whether to create a GitHub Release for the new tag.                    | No       | `'false'`             |
 
 > [!TIP]
 > Set any of `label-major`, `label-minor`, or `label-patch` to an empty string (`''`) if you want to disable that bump type.

--- a/action.yaml
+++ b/action.yaml
@@ -4,43 +4,43 @@ author: 'conjikidow'
 
 inputs:
   github-token:
-    description: 'GitHub Token'
+    description: 'The GitHub token for authentication.'
     required: false
     default: ${{ github.token }}
   version-of-bump-my-version:
-    description: 'Version of bump-my-version'
+    description: 'The version of `bump-my-version` to use.'
     required: false
     default: 'latest'
   label-major:
-    description: 'Label for major update'
+    description: 'The label used to trigger a major version bump.'
     required: false
     default: 'major'
   label-minor:
-    description: 'Label for minor update'
+    description: 'The label used to trigger a minor version bump.'
     required: false
     default: 'minor'
   label-patch:
-    description: 'Label for patch update'
+    description: 'The label used to trigger a patch version bump.'
     required: false
     default: 'patch'
   branch-prefix:
-    description: 'Prefix for the version bump branch name'
+    description: 'The prefix for the version bump branch name.'
     required: false
     default: 'workflow'
   labels-to-add:
-    description: 'Labels to add to the pull request'
+    description: 'Comma-separated string of labels to add to the PR for version bumping.'
     required: false
     default: ''
   create-release:
-    description: 'Whether to create a GitHub Release for the new tag'
+    description: 'Whether to create a GitHub Release for the new tag.'
     required: false
     default: 'false'
 outputs:
   version-bumped:
-    description: "Whether the version was bumped or not"
+    description: "`true` if the version was bumped and a new tag was created; otherwise, `false`."
     value: ${{ steps.create-tag.outputs.version-bumped }}
   new-version:
-    description: "The new version number if bumped; otherwise, empty"
+    description: "The new version number (e.g., `1.2.4`). This is empty when `version-bumped` is `false`."
     value: ${{ steps.create-tag.outputs.new-version }}
 
 runs:


### PR DESCRIPTION
This PR refines the descriptions for inputs and outputs in both `README.md` and `action.yaml` to improve clarity and consistency.

Key Changes:

-   `labels-to-add` description: Clarified that it expects a comma-separated string.
-   `action.yaml` descriptions: Updated all input and output descriptions to match the more detailed and consistent phrasing used in `README.md`.